### PR TITLE
Add name to final release configuration

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -1,4 +1,5 @@
 ---
+name: grootfs
 blobstore:
   provider: s3
   options:


### PR DESCRIPTION
This name allows the v2 BOSH CLI to create a grootfs release.