### PR TITLE
fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ various reasons. See the [grootfs job spec](jobs/grootfs/spec) for more info on
 what these properties do:
 - `dropsonde_port`
 - `log_level`
-- `store_size`
+- `store_size_bytes`
 - `driver`
 - `json_output`
 - `skip_mount`


### PR DESCRIPTION
the spec says the property is `store_size_byes`

https://github.com/cloudfoundry/grootfs-release/blob/develop/jobs/grootfs/spec#L18