### PR TITLE
Add experimental_rootless_mode support

### DIFF
--- a/jobs/grootfs/spec
+++ b/jobs/grootfs/spec
@@ -16,7 +16,7 @@ packages:
 
 consumes:
   - name: rootless_link
-    type: bool
+    type: garden_rootless_link
     optional: true
 
 properties:

--- a/jobs/grootfs/spec
+++ b/jobs/grootfs/spec
@@ -14,6 +14,11 @@ packages:
   - xfs-progs
   - grootfs
 
+consumes:
+  - name: rootless_link
+    type: bool
+    optional: true
+
 properties:
   grootfs.store_size_bytes:
     description: "The size of the grootfs store. Changes to this value do not update the store on existing hosts. To resize the store, the job host must be recreated. If 0 the size will be the same as the ephemeral disk."

--- a/jobs/grootfs/templates/bin/utils.erb
+++ b/jobs/grootfs/templates/bin/utils.erb
@@ -73,7 +73,13 @@ unprivileged_root_mapping() {
 
 unprivileged_range_mapping() {
   maximus_uid=$(/var/vcap/packages/idmapper/bin/maximus)
-  echo -n "1:65536:$((maximus_uid-65536))"
+  range="1:1:$((maximus_uid-1))"
+  <% if_link('rootless_link')  do |link| %>
+    <% if link.p('garden.experimental_rootless_mode') %>
+      range="1:65536:$((maximus_uid-65536))"
+    <% end %>
+  <% end %>
+  echo -n $range
 }
 
 volume_size() {


### PR DESCRIPTION
When enabled, grootfs will use alternative uidmappings and gidmappings
Consume value from garden via bosh link

[#150710163]

Signed-off-by: Julia Nedialkova <julianedialkova@hotmail.com>