### PR TITLE
Rename grootfs.blobstore.tls.* properties

### DIFF
--- a/jobs/grootfs/spec
+++ b/jobs/grootfs/spec
@@ -7,9 +7,9 @@ templates:
   bin/pre-start.erb:                        bin/pre-start
   config/grootfs_config.yml.erb:            config/grootfs_config.yml
   config/privileged_grootfs_config.yml.erb: config/privileged_grootfs_config.yml
-  certs/blobstore.crt.erb:                  certs/blobstore.crt
-  certs/blobstore.cert.erb:                 certs/blobstore.cert
-  certs/blobstore.key.erb:                  certs/blobstore.key
+  certs/remote-layer.crt.erb:               certs/remote-layer.crt
+  certs/remote-layer.cert.erb:              certs/remote-layer.cert
+  certs/remote-layer.key.erb:               certs/remote-layer.key
 
 packages:
   - idmapper
@@ -42,9 +42,9 @@ properties:
     description: "Do not mount image root filesystem automatically, just return the mount information."
     default: false
 
-  grootfs.blobstore.tls.cert:
+  grootfs.remote_layer_tls.cert:
     description: "PEM-encoded TLS certificate that can be used for client auth"
-  grootfs.blobstore.tls.key:
+  grootfs.remote_layer_tls.key:
     description: "PEM-encoded TLS client key"
-  grootfs.blobstore.tls.ca_cert:
-    description: "PEM-encoded TLS client CA certificate for droplet download"
+  grootfs.remote_layer_tls.ca_cert:
+    description: "PEM-encoded TLS client CA certificate for layer download"

--- a/jobs/grootfs/templates/certs/blobstore.cert.erb
+++ b/jobs/grootfs/templates/certs/blobstore.cert.erb
@@ -1,3 +1,0 @@
-<% if_p("grootfs.blobstore.tls.cert") do |cert| %>
-<%= cert %>
-<% end %>

--- a/jobs/grootfs/templates/certs/blobstore.crt.erb
+++ b/jobs/grootfs/templates/certs/blobstore.crt.erb
@@ -1,3 +1,0 @@
-<% if_p("grootfs.blobstore.tls.ca_cert") do |cert| %>
-<%= cert %>
-<% end %>

--- a/jobs/grootfs/templates/certs/blobstore.key.erb
+++ b/jobs/grootfs/templates/certs/blobstore.key.erb
@@ -1,3 +1,0 @@
-<% if_p("grootfs.blobstore.tls.key") do |cert| %>
-<%= cert %>
-<% end %>

--- a/jobs/grootfs/templates/certs/remote-layer.cert.erb
+++ b/jobs/grootfs/templates/certs/remote-layer.cert.erb
@@ -1,0 +1,3 @@
+<% if_p("grootfs.remote_layer_tls.cert") do |cert| %>
+<%= cert %>
+<% end %>

--- a/jobs/grootfs/templates/certs/remote-layer.crt.erb
+++ b/jobs/grootfs/templates/certs/remote-layer.crt.erb
@@ -1,0 +1,3 @@
+<% if_p("grootfs.remote_layer_tls.ca_cert") do |cert| %>
+<%= cert %>
+<% end %>

--- a/jobs/grootfs/templates/certs/remote-layer.key.erb
+++ b/jobs/grootfs/templates/certs/remote-layer.key.erb
@@ -1,0 +1,3 @@
+<% if_p("grootfs.remote_layer_tls.key") do |cert| %>
+<%= cert %>
+<% end %>

--- a/jobs/grootfs/templates/config/grootfs_config.yml.erb
+++ b/jobs/grootfs/templates/config/grootfs_config.yml.erb
@@ -15,7 +15,7 @@ create:
   without_mount: <%= p("grootfs.skip_mount") %>
   insecure_registries: <%= p("grootfs.insecure_docker_registry_list") %>
   skip_layer_validation: true
-  blobstore_client_certificates_path: /var/vcap/jobs/grootfs/certs
+  remote_layer_client_certificates_path: /var/vcap/jobs/grootfs/certs
 
 clean:
   cache_bytes: <%= p("grootfs.cache_size_bytes") %>

--- a/jobs/grootfs/templates/config/privileged_grootfs_config.yml.erb
+++ b/jobs/grootfs/templates/config/privileged_grootfs_config.yml.erb
@@ -15,7 +15,7 @@ create:
   without_mount: <%= p("grootfs.skip_mount") %>
   insecure_registries: <%= p('grootfs.insecure_docker_registry_list') %>
   skip_layer_validation: true
-  blobstore_client_certificates_path: /var/vcap/jobs/grootfs/certs
+  remote_layer_client_certificates_path: /var/vcap/jobs/grootfs/certs
 
 clean:
   cache_bytes: <%= p("grootfs.cache_size_bytes") %>

--- a/manifests/operations/grootfs.yml
+++ b/manifests/operations/grootfs.yml
@@ -3,6 +3,7 @@
   value:
     name: grootfs
     version: latest
+
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/-
   value:
@@ -12,11 +13,23 @@
       grootfs:
         log_level: debug
         driver: overlay-xfs
-        blobstore:
-          tls:
-            cert: ((blobstore_tls.certificate))
-            key: ((blobstore_tls.private_key))
-            ca_cert: ((blobstore_tls.ca))
+        remote_layer_tls:
+          cert: ((grootfs_remote_layer_tls.certificate))
+          key: ((grootfs_remote_layer_tls.private_key))
+          ca_cert: ((grootfs_remote_layer_tls.ca))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: grootfs_remote_layer_tls
+    type: certificate
+    options:
+      ca: service_cf_internal_ca
+      common_name: cell.service.cf.internal
+      extended_key_usage:
+      - client_auth
+      - server_auth
+      alternative_names: ["*.cell.service.cf.internal"]
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/image_plugin?


### PR DESCRIPTION
Depends on https://github.com/cloudfoundry/grootfs/pull/9

The previous name was inaccurate, a better name is
grootfs.remote_layer_tls.* These certs are used to download blobs from
urls (blobstores) AND docker images.

[#151724164]